### PR TITLE
Replace ValueCow::as_bool with truthiness function

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -103,10 +103,18 @@ Conditionals are marked using an opening `if` block and a closing `endif`
 block. It can also have zero or more optional `else if` clauses and an
 optional `else` clause. A conditional renders the contents of the block
 based on the specified condition which can be any
-[**expression**](#expressions). None, `false`, zero floats and integers, as
-well as empty strings, maps, and lists are considered falsy. Everything else
-is considered truthy. A boolean expression can be negated by applying the
-prefix `not`.
+[**expression**](#expressions). An expression can be negated by applying the
+prefix `not`. The conditional evaluates the expression based on it’s
+truthiness. The following values are considered falsy, every other value is
+truthy and will pass the condition:
+
+- `None`
+- Boolean `false`
+- An integer with value `0`
+- A float with value `0.0`
+- An empty string
+- An empty list
+- An empty map
 
 Consider the following template. If the nested field `user.is_enabled` is
 returns `false` then the first paragraph would be rendered. Otherwise if

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -103,8 +103,10 @@ Conditionals are marked using an opening `if` block and a closing `endif`
 block. It can also have zero or more optional `else if` clauses and an
 optional `else` clause. A conditional renders the contents of the block
 based on the specified condition which can be any
-[**expression**](#expressions) but it must resolve to a boolean value.  A
-boolean expression can be negated by applying the prefix `not`.
+[**expression**](#expressions). None, `false`, zero floats and integers, as
+well as empty strings, maps, and lists are considered falsy. Everything else
+is considered truthy. A boolean expression can be negated by applying the
+prefix `not`.
 
 Consider the following template. If the nested field `user.is_enabled` is
 returns `false` then the first paragraph would be rendered. Otherwise if

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -19,7 +19,7 @@ fn main() -> upon::Result<()> {
 
     let output = upon::Engine::new()
         .compile("Hello {{ user.name }}!")?
-        .render(&ctx)?;
+        .render(ctx)?;
 
     println!("{output}");
 

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -175,10 +175,7 @@ impl Compiler {
     fn update_jump(&mut self, i: usize) {
         let n = self.instrs.len();
         let j = match &mut self.instrs[i] {
-            Instr::Jump(j)
-            | Instr::JumpIfTrue(j)
-            | Instr::JumpIfFalse(j)
-            | Instr::LoopNext(j) => j,
+            Instr::Jump(j) | Instr::JumpIfTrue(j) | Instr::JumpIfFalse(j) | Instr::LoopNext(j) => j,
             _ => panic!("not a jump instr"),
         };
         *j = n;

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -81,14 +81,13 @@ impl Compiler {
                 then_branch,
                 else_branch,
             }) => {
-                let span = cond.span();
                 self.compile_expr(cond);
 
                 // then branch
                 let instr = if not {
-                    Instr::JumpIfTrue(FIXME, span)
+                    Instr::JumpIfTrue(FIXME)
                 } else {
-                    Instr::JumpIfFalse(FIXME, span)
+                    Instr::JumpIfFalse(FIXME)
                 };
                 let j = self.push(instr);
                 self.compile_scope(then_branch);
@@ -177,8 +176,8 @@ impl Compiler {
         let n = self.instrs.len();
         let j = match &mut self.instrs[i] {
             Instr::Jump(j)
-            | Instr::JumpIfTrue(j, _)
-            | Instr::JumpIfFalse(j, _)
+            | Instr::JumpIfTrue(j)
+            | Instr::JumpIfFalse(j)
             | Instr::LoopNext(j) => j,
             _ => panic!("not a jump instr"),
         };

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -128,15 +128,15 @@ impl<'a> Renderer<'a> {
                     continue;
                 }
 
-                Instr::JumpIfTrue(j, span) => {
-                    if expr.take().unwrap().as_bool(&t.source, *span)? {
+                Instr::JumpIfTrue(j) => {
+                    if expr.take().unwrap().as_bool() {
                         *pc = *j;
                         continue;
                     }
                 }
 
-                Instr::JumpIfFalse(j, span) => {
-                    if !expr.take().unwrap().as_bool(&t.source, *span)? {
+                Instr::JumpIfFalse(j) => {
+                    if !expr.take().unwrap().as_bool() {
                         *pc = *j;
                         continue;
                     }

--- a/src/render/value.rs
+++ b/src/render/value.rs
@@ -1,20 +1,16 @@
 use crate::types::ast;
-use crate::types::span::Span;
 use crate::value::ValueCow;
 use crate::{Error, Result, Value};
 
 impl ValueCow<'_> {
-    pub fn as_bool(&self, source: &str, span: Span) -> Result<bool> {
+    pub fn as_bool(&self) -> bool {
         match &**self {
-            Value::Bool(cond) => Ok(*cond),
-            value => {
-                let v = value.human();
-                Err(Error::render(
-                    format!("expected bool, but expression evaluated to {v}"),
-                    source,
-                    span,
-                ))
-            }
+            Value::None | Value::Bool(false) | Value::Integer(0) => false,
+            Value::Float(n) if *n == 0.0 => false,
+            Value::String(s) if s.is_empty() => false,
+            Value::List(l) if l.is_empty() => false,
+            Value::Map(m) if m.is_empty() => false,
+            _ => true,
         }
     }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -85,10 +85,17 @@
 //! block. It can also have zero or more optional `else if` clauses and an
 //! optional `else` clause. A conditional renders the contents of the block
 //! based on the specified condition which can be any
-//! [**expression**](#expressions). None, `false`, zero floats and integers, as
-//! well as empty strings, maps, and lists are considered falsy. Everything else
-//! is considered truthy. A boolean expression can be negated by applying the
-//! prefix `not`.
+//! [**expression**](#expressions). An expression can be negated by applying the
+//! prefix `not`. The conditional evaluates the expression based on it's
+//! truthiness. The following values are considered falsy, every other value is
+//! truthy and will pass the condition:
+//! - `None`
+//! - Boolean `false`
+//! - An integer with value `0`
+//! - A float with value `0.0`
+//! - An empty string
+//! - An empty list
+//! - An empty map
 //!
 //! Consider the following template. If the nested field `user.is_enabled` is
 //! returns `false` then the first paragraph would be rendered. Otherwise if

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -85,8 +85,10 @@
 //! block. It can also have zero or more optional `else if` clauses and an
 //! optional `else` clause. A conditional renders the contents of the block
 //! based on the specified condition which can be any
-//! [**expression**](#expressions) but it must resolve to a boolean value.  A
-//! boolean expression can be negated by applying the prefix `not`.
+//! [**expression**](#expressions). None, `false`, zero floats and integers, as
+//! well as empty strings, maps, and lists are considered falsy. Everything else
+//! is considered truthy. A boolean expression can be negated by applying the
+//! prefix `not`.
 //!
 //! Consider the following template. If the nested field `user.is_enabled` is
 //! returns `false` then the first paragraph would be rendered. Otherwise if

--- a/src/types/program.rs
+++ b/src/types/program.rs
@@ -21,10 +21,10 @@ pub enum Instr {
     Jump(usize),
 
     /// Jump to the instruction if the current expression is true
-    JumpIfTrue(usize, Span),
+    JumpIfTrue(usize),
 
     /// Jump to the instruction if the current expression is false
-    JumpIfFalse(usize, Span),
+    JumpIfFalse(usize),
 
     /// Emit the current expression
     Emit(Span),


### PR DESCRIPTION
Not sure if you actually wanted this, but I felt that it could be useful for my application, so:
Implements a truthiness function for evaluating conditionals.

The following values are falsy:
- None
- `false`
- `0` integer and `0.0` float
- empty string, list, and map

Everything else is truthy.

Closes #9. Please let me know if there is anything you would like to see changed!