### PR TITLE
Add IntoValue trait to allow borrowed Value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@ pub use crate::types::syntax::{Syntax, SyntaxBuilder};
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 pub use crate::value::to_value;
-pub use crate::value::Value;
+pub use crate::value::{IntoValue, Value};
 
 use crate::compile::Searcher;
 #[cfg(feature = "filters")]
@@ -471,21 +471,21 @@ impl<'engine, 'source> Template<'engine, 'source> {
 
     /// Render the template to a string using the provided value.
     #[inline]
-    pub fn render_from<V>(&self, ctx: V) -> Result<String>
+    pub fn render_from<'a, V>(&self, ctx: V) -> Result<String>
     where
-        V: Into<Value>,
+        V: IntoValue<'a>,
     {
-        Renderer::new(self.engine, &self.template, &ctx.into()).render()
+        Renderer::new(self.engine, &self.template, &ctx.into_value()).render()
     }
 
     /// Render the template to a writer using the provided value.
     #[inline]
-    pub fn render_to_writer_from<W, V>(&self, writer: W, ctx: V) -> Result<()>
+    pub fn render_to_writer_from<'a, W, V>(&self, writer: W, ctx: V) -> Result<()>
     where
         W: io::Write,
-        V: Into<Value>,
+        V: IntoValue<'a>,
     {
-        Renderer::new(self.engine, &self.template, &ctx.into()).render_to_writer(writer)
+        Renderer::new(self.engine, &self.template, &ctx.into_value()).render_to_writer(writer)
     }
 
     /// Render the template to a string using the provided value function.
@@ -553,23 +553,23 @@ impl<'engine> TemplateRef<'engine> {
 
     /// Render the template to a string using the provided value.
     #[inline]
-    pub fn render_from<V>(&self, ctx: V) -> Result<String>
+    pub fn render_from<'a, V>(&self, ctx: V) -> Result<String>
     where
-        V: Into<Value>,
+        V: IntoValue<'a>,
     {
-        Renderer::new(self.engine, self.template, &ctx.into())
+        Renderer::new(self.engine, self.template, &ctx.into_value())
             .render()
             .map_err(|e| e.with_template_name(self.name))
     }
 
     /// Render the template to a writer using the provided value.
     #[inline]
-    pub fn render_to_writer_from<W, V>(&self, writer: W, ctx: V) -> Result<()>
+    pub fn render_to_writer_from<'a, W, V>(&self, writer: W, ctx: V) -> Result<()>
     where
         W: io::Write,
-        V: Into<Value>,
+        V: IntoValue<'a>,
     {
-        Renderer::new(self.engine, self.template, &ctx.into())
+        Renderer::new(self.engine, self.template, &ctx.into_value())
             .render_to_writer(writer)
             .map_err(|e| e.with_template_name(self.name))
     }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -5,6 +5,7 @@ mod from;
 #[cfg(feature = "serde")]
 mod ser;
 
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 
 pub(crate) use crate::value::cow::ValueCow;
@@ -27,5 +28,21 @@ pub enum Value {
 impl Default for Value {
     fn default() -> Self {
         Self::None
+    }
+}
+
+pub trait IntoValue<'a> {
+    fn into_value(self) -> Cow<'a, Value>;
+}
+
+impl<'a, T: Into<Value> + 'a> IntoValue<'a> for T {
+    fn into_value(self) -> Cow<'a, Value> {
+        Cow::Owned(self.into())
+    }
+}
+
+impl<'a> IntoValue<'a> for &'a Value {
+    fn into_value(self) -> Cow<'a, Value> {
+        Cow::Borrowed(self)
     }
 }


### PR DESCRIPTION
This attempts to close #16 without breaking changes (I think, at least; inference may break, but that's not a SemVer breaking change) by using approach no. 2 detailed in the original issue.

The `IntoValue` trait looks like this:
```rust
pub trait IntoValue<'a> {
    fn into_value(self) -> Cow<'a, Value>;
}
```

Leaving this as a draft because this seems a bit messy and I think other approaches (including using `V: AsRef<Value>` instead) should still be considered, if this is even a use case you'd be open to support. Any input would be appreciated.